### PR TITLE
Use subscripting

### DIFF
--- a/MinimalJSON/CoreLocationJSON.swift
+++ b/MinimalJSON/CoreLocationJSON.swift
@@ -15,7 +15,7 @@ extension CLLocationCoordinate2D: JSONInitializable {
     ///     "longitude": -122.4409553
     ///   }
     public init(json: JSONValue) throws {
-        self.latitude = try json.sub("latitude").decode()
-        self.longitude = try json.sub("longitude").decode()
+        self.latitude = try json["latitude"].decode()
+        self.longitude = try json["longitude"].decode()
     }
 }

--- a/MinimalJSON/FoundationJSON.swift
+++ b/MinimalJSON/FoundationJSON.swift
@@ -12,7 +12,7 @@ extension JSONDecodable {
     /// Decode json types that come straight from `NSJSONSerialization`
     public static func decode(json: JSONValue) throws -> Self {
         /// Try to cast types, NSJSONSerialization-native types will succeed, others will throw
-        guard let decoded = json.object as? Self else {
+        guard let decoded = json.wrapped as? Self else {
             throw JSONError(.IncompatibleType(typename: "\(Self.self)"), json: json)
         }
         return decoded

--- a/MinimalJSON/JSONValue.swift
+++ b/MinimalJSON/JSONValue.swift
@@ -80,6 +80,14 @@ extension JSONValue {
         return value
     }
     
+    public subscript(key: String) -> JSONValue {
+        do {
+            return try self.sub(key)
+        } catch {
+            return JSONValue(error: error)
+        }
+    }
+    
     /// Attempts to decode the receiver’s wrapped value as type `T`
     ///
     /// Throws a `JSONError` if the receiver does not wrap a value that can be converted into the

--- a/MinimalJSON/JSONValue.swift
+++ b/MinimalJSON/JSONValue.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public struct JSONValue {
-    internal var object: AnyObject
+    internal var wrapped: Any
     
     /// Initialize a `JSONValue` by parsing the given `NSData`
     public init(parse data: NSData) throws {
@@ -24,28 +24,28 @@ public struct JSONValue {
         self = try JSONValue(parse: data)
     }
     
-    /// Initiazlie a `JSONValue` with the given object. This assumes the object is a
+    /// Initiazlie a `JSONValue` with the given value. This assumes the value is a
     /// JSON-compatible object (or you won’t be given much benefit by wrapping it in a
     /// `JSONValue`)
-    public init(_ object: AnyObject) {
-        self.object = object
+    public init(_ any: Any) {
+        wrapped = any
     }
 }
 
 // Private helpers
 extension JSONValue {
     private func asArray() throws -> [JSONValue] {
-        guard let objectArray = self.object as? [AnyObject] else {
+        guard let objectArray = self.wrapped as? [AnyObject] else {
             throw JSONError(.IncompatibleType(typename: "array"), json: self)
         }
-        return objectArray.map(JSONValue.init)
+        return objectArray.map({ JSONValue($0) })
     }
     
     private func asDictionary() throws -> [String:JSONValue] {
-        guard let objectDictionary = self.object as? [String:AnyObject] else {
+        guard let objectDictionary = self.wrapped as? [String:AnyObject] else {
             throw JSONError(.IncompatibleType(typename: "dictionary"), json: self)
         }
-        return objectDictionary.transform(JSONValue.init)
+        return objectDictionary.transform({ JSONValue($0) })
     }
 }
 

--- a/MinimalJSONTests/MinimalJSONTests.swift
+++ b/MinimalJSONTests/MinimalJSONTests.swift
@@ -14,18 +14,18 @@ class MinimalJSONTests: XCTestCase {
     func testBasicTypes() {
         doFailingErrors {
             let json = try loadJSONNamed("types")
-            try assertEqual(json.sub("integer").decode() as Int, 42)
-            try assertEqual(json.sub("double").decode() as Double, 3.14)
-            try assertEqual(json.sub("string").decode() as String, "hello, world")
-            try assertEqual(json.sub("boolean").decode() as Bool, false)
-            try assertEqual(json.sub("array_string").decode() as [String], ["hello", "world"])
-            try assertEqual(json.sub("array_int").decode() as [Int], [1, 2, 3, 4, 5])
-            try assertEqual(json.sub("array_double").decode() as [Double], [1.2, 3.4, 5.6])
-            try assertEqual(json.sub("array_empty").decode() as [String], [])
-            try assertEqual(json.sub("array_empty").decode() as [Int], [])
-            try assertEqual(json.sub("array_empty").decode() as [NSURL], [])
-            try assertEqual(json.sub("dictionary").sub("integer").decode() as Int, 64)
-            try assertEqual(json.sub("dictionary").sub("string").decode() as String, "apples")
+            try assertEqual(json["integer"].decode() as Int, 42)
+            try assertEqual(json["double"].decode() as Double, 3.14)
+            try assertEqual(json["string"].decode() as String, "hello, world")
+            try assertEqual(json["boolean"].decode() as Bool, false)
+            try assertEqual(json["array_string"].decode() as [String], ["hello", "world"])
+            try assertEqual(json["array_int"].decode() as [Int], [1, 2, 3, 4, 5])
+            try assertEqual(json["array_double"].decode() as [Double], [1.2, 3.4, 5.6])
+            try assertEqual(json["array_empty"].decode() as [String], [])
+            try assertEqual(json["array_empty"].decode() as [Int], [])
+            try assertEqual(json["array_empty"].decode() as [NSURL], [])
+            try assertEqual(json["dictionary"]["integer"].decode() as Int, 64)
+            try assertEqual(json["dictionary"]["string"].decode() as String, "apples")
         }
     }
     
@@ -36,9 +36,9 @@ class MinimalJSONTests: XCTestCase {
         
         doFailingErrors {
             let json = try loadJSONNamed("foundation_types")
-            try assertEqual(json.sub("url").decode() as NSURL, controlURL)
-            try assertEqual(json.sub("date").decode() as NSDate, controlDate)
-            try assertEqual(json.sub("timezone").decode() as NSTimeZone, controlTimeZone)
+            try assertEqual(json["url"].decode() as NSURL, controlURL)
+            try assertEqual(json["date"].decode() as NSDate, controlDate)
+            try assertEqual(json["timezone"].decode() as NSTimeZone, controlTimeZone)
         }
     }
     

--- a/MinimalJSONTests/TestModel.swift
+++ b/MinimalJSONTests/TestModel.swift
@@ -24,9 +24,9 @@ internal struct Person {
 
 extension Person: JSONInitializable {
     internal init(json: JSONValue) throws {
-        self.id = try json.sub("id").decode()
-        self.name = try json.sub("name").decode()
-        self.website = try? json.sub("website").decode()
+        self.id = try json["id"].decode()
+        self.name = try json["name"].decode()
+        self.website = try? json["website"].decode()
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This primarily set out to fulfill my own desire to have my JSON parsing happen w
 
 Types can implement `JSONInitializable` (best for value types) or `JSONDecodable` (better for classes because initializers from protocols is painful).
 
-All `JSONValue` “subscripting”<sup><a href="#sub">1</a></sup> and decoding methods throw, so errors can naturally flow to the top of your parser (or use `try?` to ignore acceptable errors such as optional keys).
+`JSONValue` uses Swift 2 error handling in order to let errors flow to the top of your parser (or use `try?` to ignore acceptable errors such as optional keys), while focusing decoding code on the happy path. The `decode()` and `sub()` methods throw errors, and the `JSONValue`’s subscript method propagates any errors to the returned `JSONValue`<sup><a href="#sub">1</a></sup> (to be thrown later when trying to `decode()`).
 
 ## Example
 
@@ -24,10 +24,10 @@ struct Person {
 
 extension Person: JSONInitializable {
     init(json: JSONValue) throws {
-        self.id = try json.sub("id").decode()
-        self.name = try json.sub("name").decode()
-        self.birthday = try? json.sub("birthday").decode()
-        self.website = try? json.sub("website").decode()
+        self.id = try json["id"].decode()
+        self.name = try json["name"].decode()
+        self.birthday = try? json["birthday"].decode()
+        self.website = try? json["urls"]["main_website"].decode()
     }
 }
 


### PR DESCRIPTION
Since `subscript` can’t throw errors (yet?), I originally opted to instead implement a throwing `sub(key: String)` method. But that made pulling values out of a `JSONValue` pretty ugly. This brings subscripting back by propagating errors to subsequent `JSONValue`s, to be thrown later (typically by `decode()`).

Making this a pull request so I can sit on it for a bit, but I plan on merging this in.
