### PR TITLE
Make JSONValue conform to CollectionType

### DIFF
--- a/MinimalJSON/JSONError.swift
+++ b/MinimalJSON/JSONError.swift
@@ -35,3 +35,14 @@ extension JSONError: CustomDebugStringConvertible {
         return "JSONError(\(type), json: \(jsonString))"
     }
 }
+
+extension JSONErrorType: Equatable { }
+public func ==(lhs: JSONErrorType, rhs: JSONErrorType) -> Bool {
+    switch (lhs, rhs) {
+    case (.UnableToParse, .UnableToParse): return true
+    case let (.MissingKey(l), .MissingKey(r)): return l == r
+    case let (.OutOfBounds(l), .OutOfBounds(r)): return l == r
+    case let (.IncompatibleType(l), .IncompatibleType(r)): return l == r
+    default: return false
+    }
+}

--- a/MinimalJSON/JSONValue.swift
+++ b/MinimalJSON/JSONValue.swift
@@ -148,3 +148,21 @@ extension JSONValue {
         return objectDictionary
     }
 }
+
+
+extension JSONValue : CollectionType {
+    public var startIndex: Int {
+        return 0
+    }
+    /// The `endIndex` of the collection that is wrapped by this JSONValue. If
+    /// the wrapped value is not a collection, this return 1 so that in most
+    /// common cases you will try to subscript the JSONValue, resulting in an
+    /// error. (Since `endIndex` itself cannot throw an error)
+    public var endIndex: Int {
+        do {
+            return try asArray().endIndex
+        } catch {
+            return 1
+        }
+    }
+}

--- a/MinimalJSONTests/MinimalJSONTests.swift
+++ b/MinimalJSONTests/MinimalJSONTests.swift
@@ -72,4 +72,38 @@ class MinimalJSONTests: XCTestCase {
             try assertEqual(json[-1]["id"].decode() as Int, 4)
         }
     }
+    
+    func testCollectionConformance() {
+        doFailingErrors {
+            let json = try loadJSONNamed("array_person")
+            assertEqual(json.startIndex, 0)
+            assertEqual(json.endIndex, 3)
+            assertEqual(json.count, 3)
+            let controlNames = ["Ben", "Chris", "Kat"]
+            for (i, personJSON) in json.enumerate() {
+                try assertEqual(personJSON["name"].decode() as String, controlNames[i])
+            }
+        }
+    }
+    
+    func testNonCollection() {
+        doFailingErrors {
+            let json = try loadJSONNamed("foundation_types")
+            assertEqual(json.startIndex, 0)
+            // Expect 1 as per JSONValue's conformance to CollectionType
+            assertEqual(json.endIndex, 1)
+            assertEqual(json.count, 1)
+            for jsonPart in json {
+                do {
+                    let _: AnyObject = try jsonPart.decode()
+                    XCTFail("Should not be able to enumerate non-array")
+                } catch let error as JSONError {
+                    XCTAssertEqual(error.type, JSONErrorType.IncompatibleType(typename: "array"))
+                } catch {
+                    XCTFail("Unexpected error \(error)")
+                }
+                
+            }
+        }
+    }
 }


### PR DESCRIPTION
This allows you to do the following:

``` swift
for personJSON in json["results"] {
    let name: String = personJSON["name"].decode()
    print(name)
}
```

Note the comment on `endIndex` wrt the behavior when the `JSONValue` is not itself wrapping an array.

(Doing the ol’ self-pull-request thing again so I can sit on this for a bit while it bakes.)
